### PR TITLE
[feat][#50] 모임원 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/ringgo/common/exception/ApplicationException.kt
+++ b/src/main/kotlin/com/ringgo/common/exception/ApplicationException.kt
@@ -1,6 +1,6 @@
 package com.ringgo.common.exception
 
-open class BusinessException(
+open class ApplicationException(
     val errorCode: ErrorCode,
     message: String? = errorCode.message
 ) : RuntimeException(message)

--- a/src/main/kotlin/com/ringgo/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/ringgo/common/exception/GlobalExceptionHandler.kt
@@ -14,8 +14,8 @@ class GlobalExceptionHandler {
         private val log = KotlinLogging.logger {}
     }
 
-    @ExceptionHandler(BusinessException::class)
-    fun handleBusinessException(e: BusinessException) = ResponseEntity
+    @ExceptionHandler(ApplicationException::class)
+    fun handleApplicationException(e: ApplicationException) = ResponseEntity
         .status(e.errorCode.status)
         .body(CommonResponse.error(e.errorCode.status.value(), e.errorCode.message))
 

--- a/src/main/kotlin/com/ringgo/domain/meeting/config/MeetingInviteConfig.kt
+++ b/src/main/kotlin/com/ringgo/domain/meeting/config/MeetingInviteConfig.kt
@@ -1,6 +1,6 @@
 package com.ringgo.domain.meeting.config
 
-import com.ringgo.common.exception.BusinessException
+import com.ringgo.common.exception.ApplicationException
 import com.ringgo.common.exception.ErrorCode
 import org.springframework.boot.context.properties.ConfigurationProperties
 
@@ -11,6 +11,6 @@ data class MeetingInviteConfig(
     var maxMembers: Int = 5,
 ) {
     init {
-        if (baseUrl.isBlank()) throw BusinessException(ErrorCode.INVALID_BASE_URL)
+        if (baseUrl.isBlank()) throw ApplicationException(ErrorCode.INVALID_BASE_URL)
     }
 }

--- a/src/main/kotlin/com/ringgo/domain/meeting/controller/MeetingController.kt
+++ b/src/main/kotlin/com/ringgo/domain/meeting/controller/MeetingController.kt
@@ -99,4 +99,20 @@ class MeetingController(
             meetingName = member.meeting.name
         )
     }
+
+    @Operation(summary = "모임원 목록 조회", description = "특정 모임의 모든 모임원 목록을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "모임원 목록 조회 성공"),
+            ApiResponse(responseCode = "403", description = "권한 없음"),
+            ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음")
+        ]
+    )
+    @GetMapping("/{id}/members")
+    fun getMembers(
+        @PathVariable id: UUID,
+        @AuthenticationPrincipal user: User
+    ): List<MeetingDto.Member.Response> {
+        return meetingService.getMembers(id, user)
+    }
 }

--- a/src/main/kotlin/com/ringgo/domain/meeting/dto/MeetingDto.kt
+++ b/src/main/kotlin/com/ringgo/domain/meeting/dto/MeetingDto.kt
@@ -97,4 +97,28 @@ class MeetingDto {
             val meetingName: String
         )
     }
+
+    @Schema(description = "모임원 목록 조회")
+    class Member {
+        @Schema(description = "모임원 목록 조회 응답")
+        data class Response(
+            @Schema(description = "모임원 ID")
+            val id: UUID,
+
+            @Schema(description = "사용자 ID")
+            val userId: UUID,
+
+            @Schema(description = "사용자 이름")
+            val name: String,
+
+            @Schema(description = "사용자 이메일")
+            val email: String,
+
+            @Schema(description = "모임원 역할")
+            val role: String,
+
+            @Schema(description = "가입일시")
+            val joinedAt: Instant,
+        )
+    }
 }

--- a/src/main/kotlin/com/ringgo/domain/meeting/entity/MeetingInvite.kt
+++ b/src/main/kotlin/com/ringgo/domain/meeting/entity/MeetingInvite.kt
@@ -1,6 +1,6 @@
 package com.ringgo.domain.meeting.entity
 
-import com.ringgo.common.exception.BusinessException
+import com.ringgo.common.exception.ApplicationException
 import com.ringgo.common.exception.ErrorCode
 import com.ringgo.domain.member.repository.MemberRepository
 import com.ringgo.domain.user.entity.User
@@ -56,7 +56,7 @@ class MeetingInvite(
         private fun validateMemberLimit(meeting: Meeting, memberRepository: MemberRepository) {
             val memberCount = memberRepository.countByMeetingId(meeting.id)
             if (memberCount >= 5) {
-                throw BusinessException(ErrorCode.MEETING_MEMBER_LIMIT_EXCEEDED)
+                throw ApplicationException(ErrorCode.MEETING_MEMBER_LIMIT_EXCEEDED)
             }
         }
 

--- a/src/main/kotlin/com/ringgo/domain/meeting/entity/enums/MeetingStatus.kt
+++ b/src/main/kotlin/com/ringgo/domain/meeting/entity/enums/MeetingStatus.kt
@@ -1,6 +1,6 @@
 package com.ringgo.domain.meeting.entity.enums
 
-import com.ringgo.common.exception.BusinessException
+import com.ringgo.common.exception.ApplicationException
 import com.ringgo.common.exception.ErrorCode
 import io.github.oshai.kotlinlogging.KotlinLogging
 
@@ -20,7 +20,7 @@ enum class MeetingStatus {
 
         if (!isValid) {
             log.warn { "Invalid status transition - from: $this, to: $newStatus" }
-            throw BusinessException(ErrorCode.INVALID_STATUS_TRANSITION)
+            throw ApplicationException(ErrorCode.INVALID_STATUS_TRANSITION)
         }
     }
 }

--- a/src/main/kotlin/com/ringgo/domain/member/entity/Member.kt
+++ b/src/main/kotlin/com/ringgo/domain/member/entity/Member.kt
@@ -1,6 +1,6 @@
 package com.ringgo.domain.member.entity
 
-import com.ringgo.common.exception.BusinessException
+import com.ringgo.common.exception.ApplicationException
 import com.ringgo.common.exception.ErrorCode
 import com.ringgo.domain.meeting.entity.Meeting
 import com.ringgo.domain.member.entity.enums.MemberRole
@@ -41,6 +41,9 @@ class Member(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var role: MemberRole,
+
+    @Column(name = "joined_at", nullable = false)
+    val joinedAt: Instant = Instant.now(),
 ) {
     companion object {
         private val log = KotlinLogging.logger {}
@@ -57,7 +60,7 @@ class Member(
     fun validateCreatorRole() {
         if (role != MemberRole.CREATOR) {
             log.warn { "User is not creator - memberId: $id, userId: ${user.id}, userRole: $role" }
-            throw BusinessException(ErrorCode.NOT_MEETING_CREATOR)
+            throw ApplicationException(ErrorCode.NOT_MEETING_CREATOR)
         }
     }
 }

--- a/src/main/kotlin/com/ringgo/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/ringgo/domain/member/repository/MemberRepository.kt
@@ -8,4 +8,5 @@ interface MemberRepository : JpaRepository<Member, Long>, MemberRepositoryCustom
     fun findByMeetingIdAndUserId(meetingId: UUID, userId: UUID): Member?
     fun countByMeetingId(meetingId: UUID): Long
     fun existsByMeetingIdAndUserId(meetingId: UUID, userId: UUID): Boolean
+    fun findByMeetingIdOrderByJoinedAtAsc(meetingId: UUID): List<Member>
 }


### PR DESCRIPTION
## 관련 이슈
- resolve #50

## 작업 내용
- [x] 모임원 목록 조회 API 구현
  - `GET /api/v1/meeting/{id}/members` 엔드포인트 추가
  - `Member` DTO 응답 클래스 구현
  - 모임원 목록 조회 서비스 로직 구현
- [x] `Member` 엔티티 누락 필드 추가
  - 기존 스키마에 있던 `joinedAt` 필드를 코드에 추가
- [x] `BusinessException`을 `ApplicationException`으로 이름 변경
  - 더 명확한 의미 전달을 위한 네이밍 변경
  - 관련 코드 전체 리팩토링
- [x] 리포지토리 기능 추가
  - `MemberRepository`에 `findByMeetingIdOrderByJoinedAtAsc` 메서드 추가
  - 가입 시점 순으로 모임원 목록 조회 지원

## 이슈 및 해결 과정
- `BusinessException`의 경우 비즈니스 규칙 외의 애플리케이션 전반의 예외도 포함하고 있어 `ApplicationException`으로 변경하였습니다.
- 코드에서 누락되었던 `joinedAt` 필드를 스키마에 맞춰 추가하였습니다.

## 테스트 방법
1. **모임원 목록 조회 API 테스트**
   - `GET /api/v1/meeting/{id}/members` 요청 시 정상적으로 모임원 목록이 조회되는지 확인합니다.
   - 응답 예시:
   
     ```json
     [
       {
        "id": "5e98fe39-a4ba-4c3b-8caa-8801e0b2d5de",
        "userId": "bc0de3e8-d0e5-11ef-97fd-2cf05d34818a",
        "name": "신짱구",
        "email": "shinnosuke@test.com",
        "role": "CREATOR",
        "joinedAt": "2025-02-09T17:38:17.126178Z"
       }
     ]
     ```

2. **예외 케이스 테스트**
   - 존재하지 않는 모임: 404 Not Found
   - 모임의 멤버가 아닌 경우: 403 Forbidden

3. **단위 테스트 실행**
   - `MeetingControllerTest`에서 다음 사항들을 검증:
     - 정상적인 모임원 목록 조회가 성공하는지 확인합니다.
     - 빈 목록이 정상적으로 반환되는지 확인합니다.
     - 각 예외 상황에서 적절한 에러 응답이 반환되는지 확인합니다.

## 참고 사항