### PR TITLE
[feat][#60] 소비 기록 검색 API 구현

### DIFF
--- a/src/main/kotlin/com/ringgo/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/ringgo/common/exception/ErrorCode.kt
@@ -9,11 +9,12 @@ enum class ErrorCode(
 ) {
     // Common
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다"),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "지원하지 않는 메서드입니다"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 오류가 발생했습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 오류가 발생했습니다"),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "C003", "필수 파라미터가 누락되었습니다"),
+    INVALID_PARAMETER_VALUE(HttpStatus.BAD_REQUEST, "C004", "파라미터 값이 올바르지 않습니다"),
 
-    // Configuration 관련 에러 추가
-    INVALID_BASE_URL(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "base-url 설정이 잘못되었습니다"),
+    // Configuration 관련
+    INVALID_BASE_URL(HttpStatus.INTERNAL_SERVER_ERROR, "C005", "base-url 설정이 잘못되었습니다"),
 
     // 모임 관련 에러
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "모임을 찾을 수 없습니다"),
@@ -42,4 +43,7 @@ enum class ErrorCode(
     INVALID_EXPENSE_AMOUNT(HttpStatus.BAD_REQUEST, "E002", "올바르지 않은 지출 금액입니다"),
     INVALID_EXPENSE_CATEGORY(HttpStatus.BAD_REQUEST, "E003", "올바르지 않은 지출 카테고리입니다"),
     NOT_EXPENSE_CREATOR(HttpStatus.FORBIDDEN, "E004", "지출 기록 작성자만 가능합니다"),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "E005", "종료일이 시작일보다 빠를 수 없습니다"),
+    INVALID_FUTURE_DATE(HttpStatus.BAD_REQUEST, "E006", "미래 날짜는 입력할 수 없습니다"),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "E007", "날짜 형식(YYYY-MM-DD)이 올바르지 않거나 존재하지 않는 날짜입니다")
 }

--- a/src/main/kotlin/com/ringgo/common/exception/ErrorResponse.kt
+++ b/src/main/kotlin/com/ringgo/common/exception/ErrorResponse.kt
@@ -8,4 +8,9 @@ data class ErrorResponse(
         code = errorCode.code,
         message = errorCode.message
     )
+
+    constructor(errorCode: ErrorCode, details: String) : this(
+        code = errorCode.code,
+        message = "${errorCode.message}: $details"
+    )
 }

--- a/src/main/kotlin/com/ringgo/domain/expense/controller/ExpenseController.kt
+++ b/src/main/kotlin/com/ringgo/domain/expense/controller/ExpenseController.kt
@@ -130,8 +130,6 @@ class ExpenseController(
             page = page,
             size = size
         )
-        request.validate()
-
         return expenseService.search(request, user)
     }
 }

--- a/src/main/kotlin/com/ringgo/domain/expense/controller/ExpenseController.kt
+++ b/src/main/kotlin/com/ringgo/domain/expense/controller/ExpenseController.kt
@@ -9,9 +9,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 @Tag(name = "Expense", description = "지출 API")
 @RestController
@@ -95,5 +97,43 @@ class ExpenseController(
     ): ExpenseDto.Get.Response {
         log.info { "List expense request: $request" }
         return expenseService.list(request, user)
+    }
+
+    @Operation(summary = "지출 검색", description = "지출을 검색합니다. 검색어는 지출명, 사용자명, 금액, 설명을 통합 검색합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "검색 성공"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            ApiResponse(responseCode = "403", description = "권한 없음"),
+            ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
+        ]
+    )
+    @GetMapping("/search")
+    fun search(
+        @RequestParam(name = "activityId") activityId: Long,
+        @RequestParam(name = "keyword", required = false) keyword: String?,
+        @RequestParam(name = "startDate", required = false)
+        @DateTimeFormat(pattern = "yyyy-MM-dd") startDate: LocalDate?,
+        @RequestParam(name = "endDate", required = false)
+        @DateTimeFormat(pattern = "yyyy-MM-dd") endDate: LocalDate?,
+        @RequestParam(name = "sortOrder", required = false, defaultValue = "false") sortOrder: Boolean,
+        @RequestParam(name = "page", required = false, defaultValue = "0") page: Int,
+        @RequestParam(name = "size", required = false, defaultValue = "20") size: Int,
+        @AuthenticationPrincipal user: User
+    ): ExpenseDto.Search.Response {
+        log.info { "Search expense request: activityId=$activityId, keyword=$keyword, startDate=$startDate, endDate=$endDate" }
+
+        val request = ExpenseDto.Search.Request(
+            activityId = activityId,
+            keyword = keyword,
+            startDate = startDate,
+            endDate = endDate,
+            sortOrder = sortOrder,
+            page = page,
+            size = size
+        )
+        request.validate()
+
+        return expenseService.search(request, user)
     }
 }

--- a/src/main/kotlin/com/ringgo/domain/expense/dto/ExpenseDto.kt
+++ b/src/main/kotlin/com/ringgo/domain/expense/dto/ExpenseDto.kt
@@ -1,16 +1,38 @@
 package com.ringgo.domain.expense.dto
 
-import com.ringgo.common.exception.ApplicationException
-import com.ringgo.common.exception.ErrorCode
 import com.ringgo.domain.expense.entity.enums.ExpenseCategory
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.*
 import org.springframework.format.annotation.DateTimeFormat
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.LocalDate
 import java.util.*
 
 class ExpenseDto {
+    data class ExpenseItem(
+        val id: Long,
+        val name: String,
+        val amount: BigDecimal,
+        val category: ExpenseCategory,
+        val description: String?,
+        val createdAt: Instant
+    )
+
+    data class UserExpenseCommon(
+        val userId: UUID,
+        val userName: String,
+        val expenses: List<ExpenseItem>,
+        val totalAmount: BigDecimal
+    )
+
+    data class DailyExpense(
+        @Schema(description = "날짜")
+        val date: Instant,
+        @Schema(description = "사용자별 지출 내역")
+        val userExpenses: List<UserExpenseCommon>
+    )
+
     @Schema(description = "지출 생성")
     class Create {
         @Schema(description = "지출 생성 요청", name = "ExpenseCreateRequest")
@@ -34,19 +56,17 @@ class ExpenseDto {
             val category: ExpenseCategory,
 
             @field:Size(max = 200, message = "설명은 200자를 넘을 수 없습니다")
-            @Schema(description = "설명", example = "어제 야근하느라 힘들어서 진짜 나한테 보상을 주고 싶었음.. 그래서 점심에 초밥 사먹었어요. ㅋㅋ")
+            @Schema(description = "설명")
             val description: String?,
 
             @field:NotNull(message = "지출일자는 필수입니다")
-            @Schema(description = "지출일자", example = "2025-02-14T12:00:00Z")
-            val expenseDate: Instant
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
+            @Schema(description = "지출일자", example = "2024-02-23")
+            val expenseDate: LocalDate
         )
 
-        @Schema(description = "지출 생성 응답", name = "ExpenseCreateResponse")
         data class Response(
-            @Schema(description = "지출 ID")
             val id: Long,
-            @Schema(description = "생성일시")
             val createdAt: Instant
         )
     }
@@ -70,15 +90,13 @@ class ExpenseDto {
             @Schema(description = "설명")
             val description: String?,
 
-            @Schema(description = "지출일자")
-            val expenseDate: Instant?
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
+            @Schema(description = "지출일자", example = "2024-02-23")
+            val expenseDate: LocalDate?
         )
 
-        @Schema(description = "지출 수정 응답", name = "ExpenseUpdateResponse")
         data class Response(
-            @Schema(description = "지출 ID")
             val id: Long,
-            @Schema(description = "수정일시")
             val updatedAt: Instant
         )
     }
@@ -91,48 +109,12 @@ class ExpenseDto {
             @Schema(description = "활동 ID", example = "1")
             val activityId: Long,
 
-            @Schema(description = "과거순 정렬 여부 (true: 과거순, false: 최신순)", example = "false")
+            @Schema(description = "과거순 정렬 여부", example = "false")
             val sortOrder: Boolean = false
         )
 
-        @Schema(description = "지출 목록 조회 응답", name = "ExpenseGetResponse")
         data class Response(
-            @Schema(description = "날짜별 지출 목록")
             val dailyExpenses: List<DailyExpense>
-        )
-
-        @Schema(description = "날짜별 지출 내역", name = "ExpenseGetDailyExpense")
-        data class DailyExpense(
-            @Schema(description = "날짜", example = "2024-02-15")
-            val date: Instant,
-
-            @Schema(description = "사용자별 지출 내역")
-            val userExpenses: List<UserExpense>
-        )
-
-        @Schema(description = "사용자별 지출 내역", name = "ExpenseGetUserExpense")
-        data class UserExpense(
-            @Schema(description = "사용자 ID")
-            val userId: UUID,
-
-            @Schema(description = "사용자 이름")
-            val userName: String,
-
-            @Schema(description = "지출 목록")
-            val expenses: List<ExpenseItem>,
-
-            @Schema(description = "총 지출액")
-            val totalAmount: BigDecimal
-        )
-
-        @Schema(description = "지출 항목", name = "ExpenseGetExpenseItem")
-        data class ExpenseItem(
-            val id: Long,
-            val name: String,
-            val amount: BigDecimal,
-            val category: ExpenseCategory,
-            val description: String?,
-            val createdAt: Instant,
         )
     }
 
@@ -145,107 +127,41 @@ class ExpenseDto {
             val activityId: Long,
 
             @field:Size(max = 100, message = "검색어는 100자를 넘을 수 없습니다")
-            @Schema(description = "검색어 (지출명, 사용자명, 금액, 설명)", example = "식사")
+            @Schema(description = "검색어", example = "식사")
             val keyword: String?,
 
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
             @Schema(description = "시작일", example = "2024-02-01")
             val startDate: LocalDate?,
 
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
             @Schema(description = "종료일", example = "2024-02-29")
             val endDate: LocalDate?,
 
-            @Schema(description = "정렬 순서 (true: 과거순, false: 최신순)", example = "false")
+            @Schema(description = "정렬 순서", example = "false")
             val sortOrder: Boolean = false,
 
             @field:Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
-            @Schema(description = "페이지 번호", example = "0", defaultValue = "0")
+            @Schema(description = "페이지 번호", example = "0")
             val page: Int = 0,
 
             @field:Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
             @field:Max(value = 100, message = "페이지 크기는 100을 초과할 수 없습니다")
-            @Schema(description = "페이지 크기", example = "20", defaultValue = "20")
+            @Schema(description = "페이지 크기", example = "20")
             val size: Int = 20
-        ) {
-            fun validate() {
-                validateDateRange()
-                validateFutureDate()
-            }
+        )
 
-            private fun validateDateRange() {
-                if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
-                    throw ApplicationException(ErrorCode.INVALID_DATE_RANGE)
-                }
-            }
-
-            private fun validateFutureDate() {
-                val now = LocalDate.now()
-                if (startDate?.isAfter(now) == true || endDate?.isAfter(now) == true) {
-                    throw ApplicationException(ErrorCode.INVALID_FUTURE_DATE)
-                }
-            }
-        }
-
-        @Schema(description = "지출 검색 응답", name = "ExpenseSearchResponse")
         data class Response(
-            @Schema(description = "날짜별 지출 목록")
             val dailyExpenses: List<DailyExpense>,
-
-            @Schema(description = "검색 결과 메타데이터")
             val metadata: SearchMetadata
         )
 
-        @Schema(description = "검색 결과 메타데이터", name = "ExpenseSearchMetadata")
         data class SearchMetadata(
-            @Schema(description = "총 레코드 수")
             val totalElements: Long,
-
-            @Schema(description = "총 페이지 수")
             val totalPages: Int,
-
-            @Schema(description = "현재 페이지 번호")
             val currentPage: Int,
-
-            @Schema(description = "페이지 크기")
             val pageSize: Int,
-
-            @Schema(description = "검색된 총 금액")
             val totalAmount: BigDecimal
-        )
-
-        @Schema(description = "날짜별 지출 내역", name = "ExpenseSearchDailyExpense")
-        data class DailyExpense(
-            @Schema(description = "날짜", example = "2024-02-15")
-            val date: LocalDate,
-
-            @Schema(description = "사용자별 지출 내역")
-            val userExpenses: List<UserExpense>
-        )
-
-        @Schema(description = "사용자별 지출 내역", name = "ExpenseSearchUserExpense")
-        data class UserExpense(
-            @Schema(description = "사용자 ID")
-            val userId: UUID,
-
-            @Schema(description = "사용자 이름")
-            val userName: String,
-
-            @Schema(description = "지출 목록")
-            val expenses: List<ExpenseItem>,
-
-            @Schema(description = "총 지출액")
-            val totalAmount: BigDecimal
-        )
-
-        @Schema(description = "지출 항목", name = "ExpenseSearchExpenseItem")
-        data class ExpenseItem(
-            val id: Long,
-            val name: String,
-            val amount: BigDecimal,
-            val category: ExpenseCategory,
-            val description: String?,
-            val createdAt: Instant
         )
     }
 }

--- a/src/main/kotlin/com/ringgo/domain/expense/entity/Expense.kt
+++ b/src/main/kotlin/com/ringgo/domain/expense/entity/Expense.kt
@@ -1,10 +1,6 @@
 package com.ringgo.domain.expense.entity
 
-import com.ringgo.common.exception.ApplicationException
-import com.ringgo.common.exception.ErrorCode
 import com.ringgo.domain.activity.entity.ExpenseActivity
-import com.ringgo.domain.activity.entity.enums.ActivityStatus
-import com.ringgo.domain.expense.dto.ExpenseDto
 import com.ringgo.domain.expense.entity.enums.ExpenseCategory
 import com.ringgo.domain.user.entity.User
 import jakarta.persistence.*
@@ -14,7 +10,6 @@ import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.math.BigDecimal
 import java.time.Instant
-import java.util.*
 
 @Entity
 @Table(name = "expense")
@@ -63,27 +58,16 @@ class Expense(
     @Column
     var deletedAt: Instant? = null
 
-    fun update(request: ExpenseDto.Update.Request, requesterId: UUID) {
-        if (creator.id != requesterId) {
-            throw ApplicationException(ErrorCode.NOT_EXPENSE_CREATOR)
-        }
-
-        request.name?.let { name = it }
-        request.amount?.let { amount = it }
-        request.category?.let { category = it }
-        request.description?.let { description = it }
-        request.expenseDate?.let { expenseDate = it }
+    fun update(name: String?, amount: BigDecimal?, category: ExpenseCategory?,
+               description: String?, expenseDate: Instant?) {
+        name?.let { this.name = it }
+        amount?.let { this.amount = it }
+        category?.let { this.category = it }
+        description?.let { this.description = it }
+        expenseDate?.let { this.expenseDate = it }
     }
 
-    fun delete(requesterId: UUID) {
-        if (creator.id != requesterId) {
-            throw ApplicationException(ErrorCode.NOT_EXPENSE_CREATOR)
-        }
-
-        if (activity.status != ActivityStatus.ACTIVE) {
-            throw ApplicationException(ErrorCode.INACTIVE_ACTIVITY)
-        }
-
+    fun markAsDeleted() {
         isDeleted = true
         deletedAt = Instant.now()
     }

--- a/src/main/kotlin/com/ringgo/domain/expense/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/com/ringgo/domain/expense/repository/ExpenseRepository.kt
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.math.BigDecimal
-import java.time.LocalDate
+import java.time.Instant
 
 @Repository
 interface ExpenseRepository : JpaRepository<Expense, Long> {
@@ -42,8 +42,8 @@ interface ExpenseRepository : JpaRepository<Expense, Long> {
     fun searchExpenses(
         @Param("activityId") activityId: Long,
         @Param("keyword") keyword: String?,
-        @Param("startDate") startDate: LocalDate?,
-        @Param("endDate") endDate: LocalDate?,
+        @Param("startDate") startDate: Instant?,
+        @Param("endDate") endDate: Instant?,
         pageable: Pageable
     ): Page<Expense>
 
@@ -65,7 +65,7 @@ interface ExpenseRepository : JpaRepository<Expense, Long> {
     fun calculateTotalAmount(
         @Param("activityId") activityId: Long,
         @Param("keyword") keyword: String?,
-        @Param("startDate") startDate: LocalDate?,
-        @Param("endDate") endDate: LocalDate?
+        @Param("startDate") startDate: Instant?,
+        @Param("endDate") endDate: Instant?
     ): BigDecimal?
 }

--- a/src/main/kotlin/com/ringgo/domain/expense/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/com/ringgo/domain/expense/repository/ExpenseRepository.kt
@@ -1,19 +1,71 @@
 package com.ringgo.domain.expense.repository
 
 import com.ringgo.domain.expense.entity.Expense
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.math.BigDecimal
+import java.time.LocalDate
 
 @Repository
 interface ExpenseRepository : JpaRepository<Expense, Long> {
-    @Query("""
+    @Query(
+        """
         SELECT e 
         FROM Expense e 
         JOIN FETCH e.creator 
         WHERE e.activity.id = :activityId 
         AND e.isDeleted = false 
         ORDER BY e.expenseDate DESC, e.createdAt DESC
-    """)
+    """
+    )
     fun findAllByActivityIdWithCreator(activityId: Long): List<Expense>
+
+    @Query("""
+        SELECT e 
+        FROM Expense e 
+        JOIN FETCH e.creator c
+        WHERE e.activity.id = :activityId 
+        AND e.isDeleted = false
+        AND (:keyword IS NULL OR (
+            LOWER(e.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR 
+            LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR 
+            LOWER(COALESCE(e.description, '')) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+            CAST(e.amount AS string) LIKE CONCAT('%', :keyword, '%')
+        ))
+        AND (:startDate IS NULL OR e.expenseDate >= :startDate)
+        AND (:endDate IS NULL OR e.expenseDate <= :endDate)
+    """)
+    fun searchExpenses(
+        @Param("activityId") activityId: Long,
+        @Param("keyword") keyword: String?,
+        @Param("startDate") startDate: LocalDate?,
+        @Param("endDate") endDate: LocalDate?,
+        pageable: Pageable
+    ): Page<Expense>
+
+    @Query("""
+        SELECT SUM(e.amount)
+        FROM Expense e 
+        JOIN e.creator c
+        WHERE e.activity.id = :activityId 
+        AND e.isDeleted = false
+        AND (:keyword IS NULL OR (
+            LOWER(e.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR 
+            LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR 
+            LOWER(COALESCE(e.description, '')) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+            CAST(e.amount AS string) LIKE CONCAT('%', :keyword, '%')
+        ))
+        AND (:startDate IS NULL OR e.expenseDate >= :startDate)
+        AND (:endDate IS NULL OR e.expenseDate <= :endDate)
+    """)
+    fun calculateTotalAmount(
+        @Param("activityId") activityId: Long,
+        @Param("keyword") keyword: String?,
+        @Param("startDate") startDate: LocalDate?,
+        @Param("endDate") endDate: LocalDate?
+    ): BigDecimal?
 }

--- a/src/main/kotlin/com/ringgo/domain/expense/service/ExpenseService.kt
+++ b/src/main/kotlin/com/ringgo/domain/expense/service/ExpenseService.kt
@@ -17,7 +17,8 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
-import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 private val log = KotlinLogging.logger {}
 
@@ -47,10 +48,9 @@ class ExpenseService(
             throw ApplicationException(ErrorCode.INVALID_EXPENSE_AMOUNT)
         }
 
-        // 5. 날짜 검증
-        if (request.expenseDate.isAfter(Instant.now())) {
-            throw ApplicationException(ErrorCode.INVALID_INPUT_VALUE)
-        }
+        // 5. 날짜 변환 및 미래 날짜 검증
+        val expenseInstant = request.expenseDate.atStartOfDay(ZoneOffset.UTC).toInstant()
+        validateFutureDate(request.expenseDate)
 
         // 6. 지출 생성 및 저장
         val expense = expenseRepository.save(
@@ -61,7 +61,7 @@ class ExpenseService(
                 amount = request.amount,
                 category = request.category,
                 description = request.description,
-                expenseDate = request.expenseDate
+                expenseDate = expenseInstant
             )
         )
 
@@ -78,23 +78,34 @@ class ExpenseService(
         val expense = expenseRepository.findByIdOrNull(id)
             ?: throw ApplicationException(ErrorCode.EXPENSE_NOT_FOUND)
 
-        // 2. 요청 데이터 검증
+        // 2. 작성자 검증
+        if (expense.creator.id != user.id) {
+            throw ApplicationException(ErrorCode.NOT_EXPENSE_CREATOR)
+        }
+
+        // 3. 금액 검증
         request.amount?.let {
             if (it <= BigDecimal.ZERO) {
                 throw ApplicationException(ErrorCode.INVALID_EXPENSE_AMOUNT)
             }
         }
 
-        request.expenseDate?.let {
-            if (it.isAfter(Instant.now())) {
-                throw ApplicationException(ErrorCode.INVALID_INPUT_VALUE)
-            }
+        // 4. 날짜 변환 및 검증
+        val expenseInstant = request.expenseDate?.let {
+            validateFutureDate(it)
+            it.atStartOfDay(ZoneOffset.UTC).toInstant()
         }
 
-        // 3. 지출 수정
-        expense.update(request, user.id)
-        log.info { "Expense updated: $id" }
+        // 5. 업데이트
+        expense.update(
+            request.name,
+            request.amount,
+            request.category,
+            request.description,
+            expenseInstant
+        )
 
+        log.info { "Expense updated: $id" }
         return ExpenseDto.Update.Response(
             id = expense.id,
             updatedAt = expense.updatedAt
@@ -121,8 +132,8 @@ class ExpenseService(
             throw ApplicationException(ErrorCode.INACTIVE_ACTIVITY)
         }
 
-        // 5. 지출 삭제 처리
-        expense.delete(user.id)
+        // 5. 삭제 처리
+        expense.markAsDeleted()
         log.info { "Expense deleted: $id" }
     }
 
@@ -135,28 +146,28 @@ class ExpenseService(
         memberRepository.findByMeetingIdAndUserId(activity.meeting.id, user.id)
             ?: throw ApplicationException(ErrorCode.NOT_MEETING_MEMBER)
 
-        // 3. 지출 목록 조회 및 변환
+        // 3. 지출 목록 조회
         val expenses = expenseRepository.findAllByActivityIdWithCreator(request.activityId)
             .groupBy { it.expenseDate }
             .map { (date, expensesForDate) ->
-                ExpenseDto.Get.DailyExpense(
+                ExpenseDto.DailyExpense(
                     date = date,
                     userExpenses = expensesForDate
                         .groupBy { it.creator }
                         .map { (user, userExpenses) ->
-                            ExpenseDto.Get.UserExpense(
+                            ExpenseDto.UserExpenseCommon(
                                 userId = user.id,
                                 userName = user.name,
                                 expenses = userExpenses
                                     .sortedBy { it.createdAt }
                                     .map { expense ->
-                                        ExpenseDto.Get.ExpenseItem(
+                                        ExpenseDto.ExpenseItem(
                                             id = expense.id,
                                             name = expense.name,
                                             amount = expense.amount,
                                             category = expense.category,
                                             description = expense.description,
-                                            createdAt = expense.createdAt,
+                                            createdAt = expense.createdAt
                                         )
                                     },
                                 totalAmount = userExpenses.sumOf { it.amount }
@@ -176,7 +187,6 @@ class ExpenseService(
         return ExpenseDto.Get.Response(dailyExpenses = expenses)
     }
 
-    @Transactional(readOnly = true)
     fun search(request: ExpenseDto.Search.Request, user: User): ExpenseDto.Search.Response {
         // 1. 활동 검증
         val activity = activityRepository.findByIdOrNull(request.activityId)?.let { it as? ExpenseActivity }
@@ -186,44 +196,51 @@ class ExpenseService(
         memberRepository.findByMeetingIdAndUserId(activity.meeting.id, user.id)
             ?: throw ApplicationException(ErrorCode.NOT_MEETING_MEMBER)
 
-        // 3. 페이징 및 정렬 설정
+        // 3. 날짜 범위 검증
+        validateDateRange(request.startDate, request.endDate)
+
+        // 4. 날짜 변환
+        val startInstant = request.startDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
+        val endInstant = request.endDate?.plusDays(1)?.atStartOfDay(ZoneOffset.UTC)?.minusNanos(1)?.toInstant()
+
+        // 5. 페이징 및 정렬 설정
         val pageable = if (request.sortOrder) {
             PageRequest.of(request.page, request.size, Sort.by(Sort.Direction.ASC, "expenseDate", "createdAt"))
         } else {
             PageRequest.of(request.page, request.size, Sort.by(Sort.Direction.DESC, "expenseDate", "createdAt"))
         }
 
-        // 4. 검색 실행
+        // 6. 검색 실행
         val searchResult = expenseRepository.searchExpenses(
             activityId = request.activityId,
             keyword = request.keyword,
-            startDate = request.startDate,
-            endDate = request.endDate,
+            startDate = startInstant,
+            endDate = endInstant,
             pageable = pageable
         )
 
-        // 5. 총 금액 계산
+        // 7. 총 금액 계산
         val totalAmount = expenseRepository.calculateTotalAmount(
             activityId = request.activityId,
             keyword = request.keyword,
-            startDate = request.startDate,
-            endDate = request.endDate,
+            startDate = startInstant,
+            endDate = endInstant
         ) ?: BigDecimal.ZERO
 
-        // 6. 응답 데이터 구성
+        // 8. 응답 데이터 구성
         val dailyExpenses = searchResult.content
             .groupBy { it.expenseDate }
             .map { (date, expensesForDate) ->
-                ExpenseDto.Search.DailyExpense(
+                ExpenseDto.DailyExpense(
                     date = date,
                     userExpenses = expensesForDate
                         .groupBy { it.creator }
                         .map { (user, userExpenses) ->
-                            ExpenseDto.Search.UserExpense(
+                            ExpenseDto.UserExpenseCommon(
                                 userId = user.id,
                                 userName = user.name,
                                 expenses = userExpenses.map { expense ->
-                                    ExpenseDto.Search.ExpenseItem(
+                                    ExpenseDto.ExpenseItem(
                                         id = expense.id,
                                         name = expense.name,
                                         amount = expense.amount,
@@ -256,5 +273,22 @@ class ExpenseService(
                 totalAmount = totalAmount
             )
         )
+    }
+
+    private fun validateFutureDate(date: LocalDate) {
+        if (date.isAfter(LocalDate.now())) {
+            throw ApplicationException(ErrorCode.INVALID_FUTURE_DATE)
+        }
+    }
+
+    private fun validateDateRange(startDate: LocalDate?, endDate: LocalDate?) {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw ApplicationException(ErrorCode.INVALID_DATE_RANGE)
+        }
+
+        val now = LocalDate.now()
+        if (startDate?.isAfter(now) == true || endDate?.isAfter(now) == true) {
+            throw ApplicationException(ErrorCode.INVALID_FUTURE_DATE)
+        }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- resolve #60

## 작업 내용
- [x] 지출 검색 API 구현
  - `GET /api/v1/expense/search` 엔드포인트 추가
  - 지출명, 사용자명, 금액, 설명에 대한 통합 검색 구현
  - 날짜 범위 검색 기능 추가 (startDate, endDate)
  - 페이지네이션 및 정렬 기능 구현
- [x] 검색 관련 에러 처리 개선
  - ErrorCode 추가: `INVALID_DATE_RANGE`, `INVALID_FUTURE_DATE`, `INVALID_DATE_FORMAT`
  - 에러 응답에 상세 메시지 추가를 위한 ErrorResponse 개선
  - `GlobalExceptionHandler`에 검색 관련 예외 처리 추가
- [x] Repository 확장
  - 통합 검색을 위한 JPA Query 구현
  - 검색 조건에 따른 총 금액 계산 쿼리 추가
- [x] 테스트 코드 중복 제거
  - 공통 테스트 데이터 생성 메소드 추출
  - 상수 값들을 companion object로 이동
  - MockHttpServletRequestBuilder 확장 함수 추가

## 이슈 및 해결 과정
1. **테스트 코드 중복**
    - 소나큐브에서 테스트 코드 중복으로 승인이 되지 않았습니다.
    - **원인 분석**:
        1. 테스트 데이터를 각 테스트에서 개별적으로 생성했습니다.
        2. 상수값들이 테스트마다 중복 정의 되었습니다.
        
    - **해결 방법**:
        1. **데이터 생성 메소드 통합**:
            - createExpenseItem(), createSearchRequest() 등 공통 메소드로 분리했습니다.
            - companion object를 사용하여 상수를 관리하는 방식으로 변경했습니다.

## 테스트 방법
1. **기본 검색 테스트**
    - Request:
    
    ```
    GET /api/v1/expense/search?activityId=1&keyword=식사
    ```
    - Response:
    
    ```json
    {
      "dailyExpenses": [
        {
          "date": "2024-02-14",
          "userExpenses": [
            {
              "userId": "...",
              "userName": "신짱구",
              "expenses": [
                {
                  "id": 1,
                  "name": "점심 식사",
                  "amount": 15000.00,
                  "category": "FOOD",
                  "description": "팀원들과 점심 식사",
                  "createdAt": "2024-02-14T12:00:00Z"
                }
              ],
              "totalAmount": 15000.00
            }
          ]
        }
      ],
      "metadata": {
        "totalElements": 1,
        "totalPages": 1,
        "currentPage": 0,
        "pageSize": 20,
        "totalAmount": 15000.00
      }
    }
    ```

2. **날짜 범위 검색 테스트**
    - Request:
    
    ```
    GET /api/v1/expense/search?activityId=1&startDate=2024-02-01&endDate=2024-02-28
    ```

3. **예외 케이스 테스트**
    - 날짜 범위 오류 (startDate > endDate): 400 응답
    - 미래 날짜 검색: 400 응답
    - 잘못된 날짜 형식: 400 응답
    - 활동을 찾을 수 없는 경우: 404 응답
    - 권한 없음: 403 응답

## 참고 사항
- 검색어는 대소문자를 구분하지 않습니다.
- 날짜 입력 형식은 'YYYY-MM-DD'입니다.
- 페이지 크기는 기본값 20, 최대 100개로 제한됩니다.
- 정렬 순서는 기본적으로 최신순이며, `sortOrder` 파라미터로 과거순 정렬도 가능합니다.
- 검색 결과에는 총 금액, 총 건수 등의 메타데이터가 포함됩니다.
- 테스트 코드는 상수를 companion object로 관리하며, 공통 메소드를 통해 데이터를 생성합니다.
- MockHttpServletRequestBuilder 확장 함수를 통해 테스트 요청 생성을 간소화했습니다.